### PR TITLE
fix: ensure /hosts returns only unique hosts

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -129,11 +129,16 @@ func (d *Database) GetHosts() ([]string, error) {
 	}
 
 	hosts := []string{}
+	uniq := map[string]bool{}
 	for obj := it.Next(); obj != nil; obj = it.Next() {
 		n, ok := obj.(Node)
 		if !ok {
 			return nil, fmt.Errorf("unable to cast node for control plane hosts: %w", err)
 		}
+		if _, exists := uniq[n.ControlPlaneHost]; exists {
+			continue
+		}
+		uniq[n.ControlPlaneHost] = true
 		hosts = append(hosts, n.ControlPlaneHost)
 	}
 	return hosts, nil


### PR DESCRIPTION
The database entries are comprised of a compound ID using go-memdb. While there is an index on the host field there is no uniqueness guarantee due to the ID being made up of node ID + host. This fix corrects /hosts from returning duplicate host entries.