### PR TITLE
fix: ensure each node creates instances in a goroutine

### DIFF
--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -14,3 +14,7 @@ kong-down:
 .PHONY: kong-up
 kong-up:
 	@docker compose -f "$(APP_DIR)/docker/kong/docker-compose.yml" up -d
+
+.PHONY: kong-up-stdout
+kong-up-stdout:
+	@docker compose -f "$(APP_DIR)/docker/kong/docker-compose.yml" up


### PR DESCRIPTION
This fix ensures that user break or error occurrence will shutdown Kheper as quickly as possible. This also adds a new make target named kong-up-stdout to allow for the viewing of Kong Gateway logs.