### PR TITLE
feat: add a reconnection mechanism for establishing connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ the configuration options available:
 |----------|----------------------|-------------|
 | `defaults.handshake_timeout` | `KHEPER_DEFAULTS_HANDSHAKE_TIMEOUT` | The amount of time allowed to complete the WebSocket handshake. (default: **15s**) |
 | `defaults.node_creation_delay` | `KHEPER_DEFAULTS_NODE_CREATION_DELAY` | The amount of time to wait before creating the next node. (default: **20ms**) |
-| `defaults.ping_interval` | `KHEPER_DEFAULTS_PING_INTERVAL` | The interval at which the node should ping the control plane. (default: **15s**) |
-| `defaults.ping_jitter` | `KHEPER_DEFAULTS_PING_JITTER` | The jitter to apply to the ping interval. (default: **5s**) |
+| `defaults.ping_interval` | `KHEPER_DEFAULTS_PING_INTERVAL` | The interval at which the node should ping the control plane. This interval must be greater than 0. (default: **15s**) |
+| `defaults.ping_jitter` | `KHEPER_DEFAULTS_PING_JITTER` | The jitter to apply to the ping interval. This jitter must be greater than 0. (default: **5s**) |
+| `defaults.reconnection_interval` | `KHEPER_DEFAULTS_RECONNECTION_INTERVAL` | The interval at which the node should attempt to reconnect to the control plane. This interval must be greater than 0.(default: **10s**) |
+| `defaults.reconnection_jitter` | `KHEPER_DEFAULTS_RECONNECTION_JITTER` | The jitter to apply to the reconnection interval. This jitter must be greater than 0. (default: **5s**) |
 
 ##### Nodes
 
@@ -105,6 +107,8 @@ defaults:
   node_creation_delay: 20ms
   ping_interval: 15s
   ping_jitter: 5s
+  reconnection_interval: 10s
+  reconnection_jitter: 5s
 
 # Node configuration for single or multiple control planes
 nodes:
@@ -155,6 +159,8 @@ export KHEPER_DEFAULTS_HANDSHAKE_TIMEOUT=15s
 export KHEPER_DEFAULTS_NODE_CREATION_DELAY=20ms
 export KHEPER_DEFAULTS_PING_INTERVAL=15s
 export KHEPER_DEFAULTS_PING_JITTER=5s
+export KHEPER_DEFAULTS_RECONNECTION_INTERVAL=10s
+export KHEPER_DEFAULTS_RECONNECTION_JITTER=5s
 
 # Nodes
 export KHEPER_NODES_INSTANCES=4
@@ -373,8 +379,6 @@ make kong-down
 - Set default values in the configuration file for all versions of Kong Gateway.
 - Incorporate a configuration section for both standard and custom plugins.
 - Include cipher suite options in the connection configuration section.
-- Develop a reconnection mechanism for nodes including initiating reconnection
-  at startup if the control plane is unavailable.
 
 ## License
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,8 @@ const (
 	defaultNodeCreationDelay       = 20 * time.Millisecond
 	defaultPingInterval            = 15 * time.Second
 	defaultPingJitter              = 5 * time.Second
+	defaultReconnectionInterval    = 10 * time.Second
+	defaultReconnectionJitter      = 5 * time.Second
 	defaultServerPort              = 5000
 	defaultServerReadTimeout       = 15 * time.Second
 	defaultServerReadHeaderTimeout = 15 * time.Second
@@ -62,6 +64,11 @@ type Defaults struct {
 	PingInterval time.Duration `yaml:"ping_interval" mapstructure:"ping_interval"`
 	// PingJitter is the jitter to apply to the ping interval.
 	PingJitter time.Duration `yaml:"ping_jitter" mapstructure:"ping_jitter"`
+	// ReconnectionInterval is the interval at which the node should attempt to
+	// reconnect to the control plane.
+	ReconnectionInterval time.Duration `yaml:"reconnection_interval" mapstructure:"reconnection_interval"`
+	// ReconnectionJitter is the jitter to apply to the reconnection interval.
+	ReconnectionJitter time.Duration `yaml:"reconnection_jitter" mapstructure:"reconnection_jitter"`
 }
 
 // Node is the configuration for the connection and mock nodes to instantiate
@@ -129,6 +136,8 @@ func NewConfig() (*Config, error) {
 	viper.SetDefault("defaults.node_creation_delay", defaultNodeCreationDelay)
 	viper.SetDefault("defaults.ping_interval", defaultPingInterval)
 	viper.SetDefault("defaults.ping_jitter", defaultPingJitter)
+	viper.SetDefault("defaults.reconnection_interval", defaultReconnectionInterval)
+	viper.SetDefault("defaults.reconnection_jitter", defaultReconnectionJitter)
 
 	// Node defaults
 	viper.SetDefault("nodes.hostname", defaultNodeHostname)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,10 +41,12 @@ func TestConfig(t *testing.T) {
 				},
 			},
 			Defaults: config.Defaults{
-				HandshakeTimeout:  15 * time.Second,
-				NodeCreationDelay: 20 * time.Millisecond,
-				PingInterval:      15 * time.Second,
-				PingJitter:        5 * time.Second,
+				HandshakeTimeout:     15 * time.Second,
+				NodeCreationDelay:    20 * time.Millisecond,
+				PingInterval:         15 * time.Second,
+				PingJitter:           5 * time.Second,
+				ReconnectionInterval: 10 * time.Second,
+				ReconnectionJitter:   5 * time.Second,
 			},
 			Nodes: []config.Node{
 				{
@@ -82,10 +84,12 @@ func TestConfig(t *testing.T) {
 				},
 			},
 			Defaults: config.Defaults{
-				HandshakeTimeout:  15 * time.Second,
-				NodeCreationDelay: 20 * time.Millisecond,
-				PingInterval:      15 * time.Second,
-				PingJitter:        5 * time.Second,
+				HandshakeTimeout:     15 * time.Second,
+				NodeCreationDelay:    20 * time.Millisecond,
+				PingInterval:         15 * time.Second,
+				PingJitter:           5 * time.Second,
+				ReconnectionInterval: 10 * time.Second,
+				ReconnectionJitter:   5 * time.Second,
 			},
 			Nodes: []config.Node{
 				{
@@ -141,10 +145,12 @@ nodes:
 				},
 			},
 			Defaults: config.Defaults{
-				HandshakeTimeout:  15 * time.Second,
-				NodeCreationDelay: 20 * time.Millisecond,
-				PingInterval:      15 * time.Second,
-				PingJitter:        5 * time.Second,
+				HandshakeTimeout:     15 * time.Second,
+				NodeCreationDelay:    20 * time.Millisecond,
+				PingInterval:         15 * time.Second,
+				PingJitter:           5 * time.Second,
+				ReconnectionInterval: 10 * time.Second,
+				ReconnectionJitter:   5 * time.Second,
 			},
 			Nodes: []config.Node{
 				{
@@ -204,10 +210,12 @@ nodes:
 				},
 			},
 			Defaults: config.Defaults{
-				HandshakeTimeout:  15 * time.Second,
-				NodeCreationDelay: 20 * time.Millisecond,
-				PingInterval:      15 * time.Second,
-				PingJitter:        5 * time.Second,
+				HandshakeTimeout:     15 * time.Second,
+				NodeCreationDelay:    20 * time.Millisecond,
+				PingInterval:         15 * time.Second,
+				PingJitter:           5 * time.Second,
+				ReconnectionInterval: 10 * time.Second,
+				ReconnectionJitter:   5 * time.Second,
 			},
 			Nodes: []config.Node{
 				{
@@ -237,6 +245,8 @@ nodes:
 		t.Setenv("KHEPER_DEFAULTS_NODE_CREATION_DELAY", "2ms")
 		t.Setenv("KHEPER_DEFAULTS_PING_INTERVAL", "3s")
 		t.Setenv("KHEPER_DEFAULTS_PING_JITTER", "4s")
+		t.Setenv("KHEPER_DEFAULTS_RECONNECTION_INTERVAL", "1s")
+		t.Setenv("KHEPER_DEFAULTS_RECONNECTION_JITTER", "2s")
 		t.Setenv("KHEPER_NODES_INSTANCES", "5")
 		t.Setenv("KHEPER_NODES_HOSTNAME", "kheper.local")
 		t.Setenv("KHEPER_NODES_ID", "unique")
@@ -257,10 +267,12 @@ nodes:
 				},
 			},
 			Defaults: config.Defaults{
-				HandshakeTimeout:  time.Second,
-				NodeCreationDelay: 2 * time.Millisecond,
-				PingInterval:      3 * time.Second,
-				PingJitter:        4 * time.Second,
+				HandshakeTimeout:     time.Second,
+				NodeCreationDelay:    2 * time.Millisecond,
+				PingInterval:         3 * time.Second,
+				PingJitter:           4 * time.Second,
+				ReconnectionInterval: 1 * time.Second,
+				ReconnectionJitter:   2 * time.Second,
 			},
 			Nodes: []config.Node{
 				{
@@ -289,10 +301,12 @@ nodes:
 				},
 			},
 			Defaults: config.Defaults{
-				HandshakeTimeout:  1 * time.Second,
-				NodeCreationDelay: 2 * time.Millisecond,
-				PingInterval:      3 * time.Second,
-				PingJitter:        4 * time.Second,
+				HandshakeTimeout:     1 * time.Second,
+				NodeCreationDelay:    2 * time.Millisecond,
+				PingInterval:         3 * time.Second,
+				PingJitter:           4 * time.Second,
+				ReconnectionInterval: 1 * time.Second,
+				ReconnectionJitter:   2 * time.Second,
 			},
 			Nodes: []config.Node{
 				{

--- a/kheper.yml
+++ b/kheper.yml
@@ -12,6 +12,8 @@ defaults:
   node_creation_delay: 20ms
   ping_interval: 15s
   ping_jitter: 5s
+  reconnection_interval: 10s
+  reconnection_jitter: 5s
 
 # Node configuration for single or multiple control planes
 nodes:


### PR DESCRIPTION
This feature adds two new configuration items to the default section: `reconnection_interval` and `reconnection_jitter`. These settings will handle the timer when a connection cannot be established to the control plane server.